### PR TITLE
EDoc / source file access for standard OTP modules

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -334,15 +334,15 @@ The clue is difference between `source` parameters.
 How to get the desired path suffix?
 
 ```
-lists:dropwhile( fun ("lib") -> false;
-                     (_) -> false end,
-                 string:tokens("/Users/erszcz/.kerl/builds/18.2/otp_src_18.2/lib/wx/src/wx.erl", "/") ).
+lists:reverse(lists:takewhile(fun ("lib") -> false; (_) -> true end,
+                              lists:reverse(string:tokens("/Users/erszcz/.kerl/builds/18.2/otp_src_18.2/lib/wx/src/wx.erl",
+                                                          "/")))).
 ```
 
 Returns:
 
 ```
-["lib","wx","src","wx.erl"]
+["wx","src","wx.erl"]
 ```
 
 How to tell if Kerl is enabled (i.e. is this Erlang activated by Kerl)?
@@ -350,6 +350,13 @@ How to tell if Kerl is enabled (i.e. is this Erlang activated by Kerl)?
 ```
 %% Returns string (truthy) or false.
 os:getenv("_KERL_PATH_REMOVABLE").
+```
+
+How to programatically get the current OTP version?
+
+```
+{ok, Version} = file:read_file([proplists:get_value(root, init:get_arguments()),
+                                "/releases/", erlang:system_info(otp_release), "/OTP_VERSION"]).
 ```
 
 Algo steps:
@@ -361,4 +368,4 @@ Algo steps:
 
     * guess the source destination (just assume/hardcode a valid value for Kerl)
     * rewrite the source path
-    * write to module to docsh cache
+    * write the module to docsh cache

--- a/notes.md
+++ b/notes.md
@@ -369,3 +369,11 @@ Algo steps:
     * guess the source destination (just assume/hardcode a valid value for Kerl)
     * rewrite the source path
     * write the module to docsh cache
+
+# 2017-05-16 False warning on EDoc / source availability
+
+A module for which we inferred the source file, once written do docsh cache,
+when processed again with h(Mod, Fun) still warns about source code
+unavailability.
+The docs extracted from source code are available, though, as they're
+already written to the cached .beam file's ExDc chunk.

--- a/snippets.erl
+++ b/snippets.erl
@@ -164,3 +164,9 @@ DMods = [ct_docsh,
          rebar3_docsh,
          rebar3_docsh_prv].
 [ dbg:tpl(M, []) || M <- DMods ].
+
+code:add_path("/Users/erszcz/work/erszcz/tracer").
+my_tracer:start().
+dbg:p(all, [call, timestamp]).
+dbg:tpl(docsh_shell, unchecked_lookup, x).
+dbg:tpl(docsh_shell, get_beam, 1, x).

--- a/src/docsh_beam.erl
+++ b/src/docsh_beam.erl
@@ -6,7 +6,7 @@
          name/1,
          abst/1,
          beam_file/1,
-         source_file/1,
+         source_file/1, source_file/2,
          attribute/2]).
 
 -export_type([t/0]).
@@ -51,6 +51,8 @@ abst(B) ->
 beam_file(B) -> B#docsh_beam.beam_file.
 
 source_file(B) -> B#docsh_beam.source_file.
+
+source_file(B, NewFile) -> B#docsh_beam{source_file = NewFile}.
 
 attribute(B, Name) ->
     docsh_lib:get(Name, (B#docsh_beam.name):module_info(attributes)).

--- a/src/docsh_lib.erl
+++ b/src/docsh_lib.erl
@@ -124,8 +124,8 @@ get_debug_info(BEAMFile) ->
 get_source_file(BEAMFile) ->
     lists:foldl(fun check_source_file/2,
                 false,
-                lists:flatten([compile_info_source_file(BEAMFile),
-                               guessed_source_file(BEAMFile)])).
+                lists:concat([compile_info_source_file(BEAMFile),
+                              guessed_source_file(BEAMFile)])).
 
 check_source_file(_SourceFile, {ok, File}) ->
     {ok, File};

--- a/src/docsh_lib.erl
+++ b/src/docsh_lib.erl
@@ -121,11 +121,20 @@ get_source_file(BEAMFile) ->
             File when is_list(File) ->
                 case filelib:is_regular(File) of
                     true -> {ok, File};
-                    _ -> false
+                    _ -> get_source_file2(BEAMFile)
                 end;
             _ -> false
         end
     catch _:_ -> false end.
+
+get_source_file2(BEAMFile) ->
+    File1 = filename:join(filename:dirname(BEAMFile), "../src"),
+    File2 = filename:basename(BEAMFile, ".beam") ++ ".erl",
+    File3 = filename:join(File1, File2),
+    case filelib:is_regular(File3) of
+        true -> {ok, File3};
+        false -> false
+    end.
 
 get_source(CompileInfo) ->
     {source, File} = lists:keyfind(source, 1, CompileInfo),

--- a/test/install_SUITE.erl
+++ b/test/install_SUITE.erl
@@ -134,8 +134,11 @@ is_container_running(Name) ->
     catch _:_ -> false end.
 
 current_git_commit() ->
-    {_, _, R} = sh("git rev-parse HEAD"),
-    R.
+    case os:getenv("TRAVIS_PULL_REQUEST_SHA") of
+        false -> {_, _, R} = sh("git rev-parse HEAD"),
+                 R;
+        Commit -> Commit
+    end.
 
 clone(Repo) ->
     ["git clone ", Repo].


### PR DESCRIPTION
Addresses #7, but still needs some more work.
Food for thought: remove module cache and always work from the basic components - debug_info and source file?