### PR TITLE
Fix inconsistent lookup times

### DIFF
--- a/snippets.erl
+++ b/snippets.erl
@@ -170,3 +170,71 @@ my_tracer:start().
 dbg:p(all, [call, timestamp]).
 dbg:tpl(docsh_erl, unchecked_lookup, x).
 dbg:tpl(docsh_erl, get_beam, 1, x).
+
+%% erl -sname docsh -setcookie qkie
+%% erl -sname remote -setcookie qkie
+
+dbg:tracer(process, {fun dbg:dhandler/2, standard_io}).
+dbg:n(docsh@x4).
+dbg:p(all, [call, arity, timestamp]).
+{ok, [Modules]} = file:consult("/Users/erszcz/work/erszcz/docsh/modules.lst").
+[ l(M) || M <- Modules ].
+rp([ {M, dbg:tpl(M, [])} || M <- Modules ]).
+TracePublic = [
+               docsh_embeddable,
+               beam_lib,
+               erl_comment_scan,
+               epp_dodger,
+               docsh_lib,
+               docsh_elixir_docs_v1,
+               erl_prettypr,
+               %erl_syntax_lib,
+               edoc,
+               %edoc_data,
+               edoc_extract,
+               edoc_lib,
+               edoc_macros,
+               edoc_parser,
+               edoc_scanner,
+               %edoc_specs,
+               edoc_tags,
+               %edoc_types,
+               xmerl_lib,
+               docsh_edoc_xmerl,
+               xmerl
+              ].
+rp([ {PM, dbg:tp(PM, [])} || PM <- TracePublic ]).
+dbg:tpl(docsh_erl, rebuild, x).
+
+docsh_tracer:start().
+dbg:n(docsh@x4).
+dbg:p(all, [call, timestamp]).
+%dbg:tpl(docsh_erl, x).
+%dbg:tpl(docsh_erl, find_cached, x).
+%dbg:tpl(docsh_erl, cached_or_rebuilt, x).
+%dbg:tpl(docsh_erl, reload, x).
+%dbg:tpl(docsh_erl, rebuild, x).
+dbg:tpl(docsh_beam, from_loadable_module, x).
+%dbg:tpl(docsh_lib, exdc, x).
+%
+%dbg:tpl(docsh_erl, cache_dir, x).
+%dbg:tpl(docsh_erl, cached_or_rebuilt, x).
+%dbg:tpl(docsh_erl, ensure_cache_dir, x).
+%dbg:tpl(docsh_erl, find_cached, x).
+%dbg:tpl(docsh_erl, get_beam, x).
+dbg:tpl(docsh_erl, h, x).
+%dbg:tpl(docsh_erl, lookup, x).
+%dbg:tpl(docsh_erl, reload, x).
+%dbg:tpl(docsh_erl, rebuild, x).
+%
+dbg:tpl(docsh_lib, get_source_file, x).
+dbg:tpl(code, which, x).
+dbg:tpl(docsh_lib, check_source_file, x).
+dbg:tpl(beam_lib, chunks, x).
+dbg:tpl(docsh_lib, compile_info_source_file, x).
+dbg:tpl(docsh_lib, guessed_source_file, x).
+dbg:tpl(filelib, is_regular, x).  %% THIS MAY TAKE ~20 SECONDS!!!111oneone
+%(docsh@x4)7> timer:tc(filelib, is_regular, ["/net/isildur/ldisk/daily_build/19_prebuild_opu_o.2016-12-12_21/otp_src_19/lib/stdlib/src/lists.erl"]).
+%{26131796,false}
+%(docsh@x4)8> timer:tc(filelib, is_regular, ["/not-net/isildur/ldisk/daily_build/19_prebuild_opu_o.2016-12-12_21/otp_src_19/lib/stdlib/src/lists.erl"]).
+%{171,false}

--- a/src/docsh_lib.erl
+++ b/src/docsh_lib.erl
@@ -129,6 +129,11 @@ get_source_file(BEAMFile) ->
 
 check_source_file(_SourceFile, {ok, File}) ->
     {ok, File};
+%% This is a special case for Erlang prebuilt .beam files.
+%% Calling filelib:is_regular/1 on non-existent files under /net might
+%% take ~20 seconds on Mac - we want to avoid it.
+check_source_file("/net" ++ _, false) ->
+    false;
 check_source_file(SourceFile, false) ->
     case filelib:is_regular(SourceFile) of
         true -> {ok, SourceFile};

--- a/src/docsh_tracer.erl
+++ b/src/docsh_tracer.erl
@@ -1,0 +1,134 @@
+-module(docsh_tracer).
+
+-compile([export_all]).
+
+-define(il2b, iolist_to_binary).
+
+%% Default dbg:dhandler/2 is nice,
+%% but when you want to use domain knowledge
+%% or discard some of the data (like too long arg lists / retvals)
+%% it might be convenient to write your own dbg handler function.
+%% However, this is error prone and since you can't trace your trace function
+%% (d'oh!) hard to debug.
+%%
+%% The way to go is to setup a monitor on the trace handler process.
+%% When the trace function errors and kills the tracer process,
+%% you'll be notified.
+%% Still, if the monitor is setup by the shell, the 'DOWN' message
+%% might simply end up in the message queue of the shell
+%% and never be received - you won't know a crash happened.
+%%
+%% So, it's best to setup a process which will monitor the trace handler
+%% and print any 'DOWN' messages it receives.
+%% This will be done in my_tracer:start/0.
+start() ->
+    %{ok, Tracer} = dbg:tracer(process, {fun ?MODULE:handler/2, standard_io}),
+    {ok, Tracer} = dbg:tracer(process, {fun ?MODULE:handler/2, user}),
+    { {tracer, Tracer},
+      {tracer_monitor, spawn_link(?MODULE, tracer_monitor, [Tracer])} }.
+
+tracer_monitor(Pid) ->
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, Info} ->
+            io:format("process ~p exited with info: ~p~n",
+                      [Pid, Info])
+    end.
+
+handler({trace_ts, _Pid, call, _MFA, TS} = Trace, Out) ->
+    print(Out, "~s ~s", [format_timestamp(TS), format_call(strip_ts(Trace))]),
+    Out;
+handler({trace, _Pid, call, _MFA} = Trace, Out) ->
+    print(Out, "~s", [format_call(Trace)]),
+    Out;
+
+handler({trace_ts, _Pid, return_from, _MFA, _Ret, TS} = Trace, Out) ->
+    print(Out, "~s ~s", [format_timestamp(TS),
+                         format_return_from(strip_ts(Trace))]),
+    Out;
+handler({trace, _Pid, return_from, _MFA, _Ret} = Trace, Out) ->
+    print(Out, "~s", [format_return_from(Trace)]),
+    Out;
+
+handler(Trace, Out) ->
+    pass_to_dbg(Trace, Out).
+
+strip_ts({trace_ts, Pid, call, MFA, _TS})             -> {trace, Pid, call, MFA};
+strip_ts({trace_ts, Pid, return_from, MFA, Ret, _TS}) -> {trace, Pid, return_from, MFA, Ret}.
+
+format_call({trace, Pid, call, {M, F, Args}} = _Trace) ->
+    [ io_lib:format("~p call ~s:~s/~b:\n", [Pid, M, F, length(Args)]),
+      [ io_lib:format("  arg ~b: ~p\n", [I, A]) || {I, A} <- enum(Args) ] ].
+
+format_return_from({trace, Pid, return_from, {M, F, Arity}, Ret} = _Trace) ->
+    [ io_lib:format("~p returned from ~s:~s/~b\n  -> ~p\n",
+                    [Pid, M, F, Arity, Ret]) ].
+
+translate_args({trace, Pid, call, {M, F, Args}}) ->
+    NewArgs = [ translate_one(Arg) || Arg <- Args ],
+    {trace, Pid, call, {M, F, NewArgs}}.
+
+translate_ret({trace, Pid, return_from, MFA, Ret}) ->
+    {trace, Pid, return_from, MFA, translate_one(Ret)}.
+
+translate_one(Val) ->
+    lists:foldl(fun (F, AccV) -> F(AccV) end, Val, translations()).
+
+translations() ->
+    [fun flatten_if_state/1,
+     fun flatten_if_fsm_next_state4/1,
+     fun flatten_if_jid/1,
+     fun flatten_if_sending_iolist/1].
+
+flatten_if_state(State) when is_tuple(State), element(1, State) == state -> state;
+flatten_if_state(Arg) -> Arg.
+
+flatten_if_fsm_next_state4({next_state, StateName, State, Timeout}) ->
+    {next_state, StateName, flatten_if_state(State), Timeout};
+flatten_if_fsm_next_state4(Arg) -> Arg.
+
+flatten_if_jid({jid, _, _, _, _, _, _} = JID) ->
+    <<"jid:", (jid:to_binary(JID))/bytes>>;
+flatten_if_jid(NotAJID) -> NotAJID.
+
+flatten_if_sending_iolist({trace, Pid, call, {ejabberd_c2s, send_text, [A1, IOList]}}) ->
+    {trace, Pid, call, {ejabberd_c2s, send_text, [A1, iolist_to_binary(IOList)]}};
+flatten_if_sending_iolist(Arg) -> Arg.
+
+pass_to_dbg(Trace, Out) ->
+    dbg:dhandler(Trace, Out),
+    io:format("~n", []),
+    Out.
+
+%% {M,F,[A1, A2, ..., AN]} -> "M:F(A1, A2, ..., AN)"
+%% {M,F,A}                 -> "M:F/A"
+ffunc({M,F,Argl}) when is_list(Argl) ->
+    io_lib:format("~p:~p(~s)", [M, F, fargs(Argl)]);
+ffunc({M,F,Arity}) ->
+    io_lib:format("~p:~p/~p", [M,F,Arity]);
+ffunc(X) -> io_lib:format("~p", [X]).
+
+%% Integer           -> "Integer"
+%% [A1, A2, ..., AN] -> "A1, A2, ..., AN"
+fargs(Arity) when is_integer(Arity) -> integer_to_list(Arity);
+fargs([]) -> [];
+fargs([A]) -> io_lib:format("~p", [A]);  %% last arg
+fargs([A|Args]) -> [io_lib:format("~p,", [A]) | fargs(Args)];
+fargs(A) -> io_lib:format("~p", [A]). % last or only arg
+
+print(Handle, Fmt, Args) ->
+    io:format(Handle, Fmt, Args).
+
+enum(L) ->
+    lists:zip(lists:seq(1, length(L)), L).
+
+format_timestamp(TS) -> format_timestamp(TS, micro).
+
+format_timestamp({_, _, Micro} = TS, Precision) ->
+    {_, {H,M,S}} = calendar:now_to_local_time(TS),
+    [io_lib:format("~2.10B:~2.10.0B:~2.10.0B", [H, M, S]),
+     case Precision of
+         seconds -> "";
+         milli   -> io_lib:format( ".~3.10.0B", [erlang:round(Micro / 1000)]);
+         micro   -> io_lib:format( ".~6.10.0B", [Micro])
+     end].

--- a/src/docsh_tracer.erl
+++ b/src/docsh_tracer.erl
@@ -75,25 +75,10 @@ translate_one(Val) ->
     lists:foldl(fun (F, AccV) -> F(AccV) end, Val, translations()).
 
 translations() ->
-    [fun flatten_if_state/1,
-     fun flatten_if_fsm_next_state4/1,
-     fun flatten_if_jid/1,
-     fun flatten_if_sending_iolist/1].
+    [fun flatten_if_state/1].
 
 flatten_if_state(State) when is_tuple(State), element(1, State) == state -> state;
 flatten_if_state(Arg) -> Arg.
-
-flatten_if_fsm_next_state4({next_state, StateName, State, Timeout}) ->
-    {next_state, StateName, flatten_if_state(State), Timeout};
-flatten_if_fsm_next_state4(Arg) -> Arg.
-
-flatten_if_jid({jid, _, _, _, _, _, _} = JID) ->
-    <<"jid:", (jid:to_binary(JID))/bytes>>;
-flatten_if_jid(NotAJID) -> NotAJID.
-
-flatten_if_sending_iolist({trace, Pid, call, {ejabberd_c2s, send_text, [A1, IOList]}}) ->
-    {trace, Pid, call, {ejabberd_c2s, send_text, [A1, iolist_to_binary(IOList)]}};
-flatten_if_sending_iolist(Arg) -> Arg.
 
 pass_to_dbg(Trace, Out) ->
     dbg:dhandler(Trace, Out),


### PR DESCRIPTION
For some time I've been noticing very inconsistent lookup times to documentation, to the point of the tool being unusable. The following `erl` dump best pictures the problem:

```
1> timer:tc(user_default, h, [lists]).

# lists

(description missing)

{20630146,ok}
2> timer:tc(user_default, h, [lists]).

# lists

(description missing)

{2071,ok}

...

7> timer:tc(user_default, h, [lists]).

# lists

(description missing)

{20275237,ok}
8> 20275237 / 1000 / 1000. %% microseconds to seconds
20.275237
```

Through tracing more and more specific parts of the lookup call chain I've managed to narrow down the problem functions first to `docsh_erl:get_beam/1`, then `docsh_lib:check_source_file/2`, and finally `filelib:is_regular/1`. The last one usually is very fast.

However, coincidentally, the source file path embedded in precompiled Erlang .beam files starts with `/net`, which quite likely means a network-mounted filesystem. It turns out that in case of non-existent files in such a filesystem the check might take orders of magnitude more time (which in and of itself is reasonable):

```
(docsh@x4)7> timer:tc(filelib, is_regular, ["/net/isildur/ldisk/daily_build/19_prebuild_opu_o.2016-12-12_21/otp_src_19/lib/stdlib/src/lists.erl"]).
{26131796,false}
(docsh@x4)8> timer:tc(filelib, is_regular, ["/not-net/isildur/ldisk/daily_build/19_prebuild_opu_o.2016-12-12_21/otp_src_19/lib/stdlib/src/lists.erl"]).
{171,false}
```

Since it's unlikely that actual users will actually have the source files placed in the exact location pointed at by the .beam files shipped from erlang.org, the applied fix is to ignore source file paths starting with `/net`.