### PR TITLE
Try generating ExDoc documentation

### DIFF
--- a/include/docsh_exdoc.hrl
+++ b/include/docsh_exdoc.hrl
@@ -1,0 +1,13 @@
+-ifndef(DOCSH_EXDOC_H).
+-define(DOCSH_EXDOC_H, true).
+
+-export(['__info__'/1]).
+
+-spec '__info__'(compile) -> [{src, binary()}].
+'__info__'(compile) ->
+    case lists:keyfind(source, 1, erlang:get_module_info(?MODULE, compile)) of
+        false -> erlang:error(no_compile_source_found);
+        {source, Source} -> [{src, list_to_binary(Source)}]
+    end.
+
+-endif. %% DOCSH_EXDOC_H

--- a/src/docsh.erl
+++ b/src/docsh.erl
@@ -71,6 +71,7 @@
 -import(docsh_lib, [print/2, print/3]).
 
 -include("docsh_stacktrace.hrl").
+-include_lib("docsh/include/docsh_exdoc.hrl").
 
 %% External documentation format as described in EEP-48:
 %% http://erlang.org/eep/eeps/eep-0048.html

--- a/src/docsh_docs_v1.erl
+++ b/src/docsh_docs_v1.erl
@@ -17,6 +17,8 @@
                   metadata,
                   docs}).
 
+-include_lib("docsh/include/docsh_exdoc.hrl").
+
 -opaque t() :: #docs_v1{anno :: erl_anno:anno(),
                         beam_language :: atom(),
                         format :: mime_type(),

--- a/src/docsh_erl.erl
+++ b/src/docsh_erl.erl
@@ -8,6 +8,8 @@
 
 -import(docsh_lib, [print/2]).
 
+-include_lib("docsh/include/docsh_exdoc.hrl").
+
 -define(a2b(A), atom_to_binary(A, utf8)).
 -define(i2b(I), integer_to_binary(I)).
 -define(il2b(IOList), iolist_to_binary(IOList)).

--- a/src/rebar3_docsh.erl
+++ b/src/rebar3_docsh.erl
@@ -30,6 +30,8 @@
               "This exposes Erlang module documentation to Elixir and other BEAM languages.\n"
               "Use https://github.com/erszcz/docsh to access your docs in an Erlang shell.\n").
 
+-include_lib("docsh/include/docsh_exdoc.hrl").
+
 %% ===================================================================
 %% Public API
 %% ===================================================================


### PR DESCRIPTION
TL;DR: it fails

wojtekmach/docs_chunks doesn't pass include flags to EDoc.
I applied the following **hack** just to check if ExDoc can handle
generating nice docs for docsh:

```
diff --git a/src/docs_chunks.erl b/src/docs_chunks.erl
index 47ea431..015e026 100644
--- a/src/docs_chunks.erl
+++ b/src/docs_chunks.erl
@@ -61,7 +61,9 @@
 %% '''
 -spec edoc_to_chunk(string()) -> docs_v1().
 edoc_to_chunk(ErlPath) ->
-    {_Module, Doc} = edoc:get_doc(ErlPath, [{preprocess, true}]),
+    Includes = ["/Users/erszcz/work/erszcz/docsh/_build/default/lib/docsh/include"],
+    Opts = [{preprocess, true}, {includes, Includes}],
+    {_Module, Doc} = edoc:get_doc(ErlPath, Opts),
     DocString = xpath_to_binary("//module/description/fullDescription", Doc),
     Docs = edoc_extract_docs(Doc),
     Chunk = docs_v1(DocString, Docs),
```

I then recompiled the script with `mix escript.build` as usual.

The command:

```
r3 compile && \
ERL_LIBS=/Users/erszcz/work/erszcz/docsh/_build/default/lib \
/Users/erszcz/work/wojtekmach/docs_chunks/docs_chunks -project && \
ex_doc docs_chunks "0.7.1" _build/default/lib/docsh/ebin -m docsh
```

Alas, the long output ends with:

```
13:55:58.535 [error] Task #PID<0.107.0> started from #PID<0.102.0> terminating
** (TokenMissingError) nofile:1: missing terminator: end (for "do" starting at line 1)
    (elixir) lib/code.ex:553: Code.format_string!/2
    (ex_doc) lib/ex_doc/formatter/html/autolink.ex:340: ExDoc.Formatter.HTML.Autolink.format_ast/1
    (ex_doc) lib/ex_doc/formatter/html/autolink.ex:288: ExDoc.Formatter.HTML.Autolink.format_and_extract_typespec_placeholders/5
    (ex_doc) lib/ex_doc/formatter/html/autolink.ex:226: ExDoc.Formatter.HTML.Autolink.typespec/5
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    (ex_doc) lib/ex_doc/formatter/html/autolink.ex:205: anonymous fn/6 in ExDoc.Formatter.HTML.Autolink.all_typespecs/2
    (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
Function: &:erlang.apply/2
    Args: [#Function<0.96756601/1 in ExDoc.Formatter.HTML.Autolink.all/2>, [%ExDoc.ModuleNode{deprecated: nil, doc: "Store modules' documentation in Docs chunks according to EEP-48.\n\n Add the following code to your project's `rebar.config`:\n\n \n```\n  {plugins,\n   [\n    {rebar3_docsh, \"0.7.1\", {pkg, docsh}}\n   ]}.\n \n \n  {provider_hooks,\n   [\n    {post, [{compile, {docsh, compile}}]}\n   ]}.\n```\n ", doc_line: 0, docs: [%ExDoc.FunctionNode{annotations: [], arity: 1, defaults: [], deprecated: nil, doc: nil, doc_line: 0, group: "Functions", id: "do/1", name: :do, rendered_doc: nil, signature: "do/1", source_path: "", source_url: nil, specs: [{:"::", [line: 54], [{:do, [line: 54], [{{:., [line: 54], [:rebar_state, :t]}, [line: 54], []}]}, {:|, [line: 54], [{:{}, [line: 54], [:ok, {{:., [line: 54], [:rebar_state, :t]}, [line: 54], []}]}, {:{}, [line: 54], [:error, {:string, [line: 54], []}]}]}]}], type: :function}, %ExDoc.FunctionNode{annotations: [], arity: 1, defaults: [], deprecated: nil, doc: nil, doc_line: 0, group: "Functions", id: "format_error/1", name: :format_error, rendered_doc: nil, signature: "format_error/1", source_path: "", source_url: nil, specs: [{:"::", [line: 65], [{:format_error, [line: 65], [{:any, [line: 65], []}]}, {:iolist, [line: 65], []}]}], type: :function}, %ExDoc.FunctionNode{annotations: [], arity: 1, defaults: [], deprecated: nil, doc: nil, doc_line: 0, group: "Functions", id: "init/1", name: :init, rendered_doc: nil, signature: "init/1", source_path: "", source_url: nil, specs: [{:"::", [line: 39], [{:init, [line: 39], [{{:., [line: 39], [:rebar_state, :t]}, [line: 39], []}]}, {:{}, [line: 39], [:ok, {{:., [line: 39], [:rebar_state, :t]}, [line: 39], []}]}]}], type: :function}], function_groups: ["Functions"], group: nil, id: "rebar3_docsh", module: :rebar3_docsh, nested_context: nil, nested_title: nil, rendered_doc: nil, source_path: "", source_url: nil, title: "rebar3_docsh", type: :module, typespecs: []}]]
** (EXIT from #PID<0.102.0>) an exception was raised:
    ** (TokenMissingError) nofile:1: missing terminator: end (for "do" starting at line 1)
        (elixir) lib/code.ex:553: Code.format_string!/2
        (ex_doc) lib/ex_doc/formatter/html/autolink.ex:340: ExDoc.Formatter.HTML.Autolink.format_ast/1
        (ex_doc) lib/ex_doc/formatter/html/autolink.ex:288: ExDoc.Formatter.HTML.Autolink.format_and_extract_typespec_placeholders/5
        (ex_doc) lib/ex_doc/formatter/html/autolink.ex:226: ExDoc.Formatter.HTML.Autolink.typespec/5
        (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
        (ex_doc) lib/ex_doc/formatter/html/autolink.ex:205: anonymous fn/6 in ExDoc.Formatter.HTML.Autolink.all_typespecs/2
        (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
```