### PR TITLE
Add missing specs

### DIFF
--- a/include/docsh_user_default.hrl
+++ b/include/docsh_user_default.hrl
@@ -2,14 +2,29 @@
          s/1, s/2, s/3,
          t/1, t/2, t/3]).
 
+-spec h(fun() | module()) -> ok.
 h(ModOrFun) -> docsh_erl:h(ModOrFun).
+
+-spec h(module(), docsh_erl:name()) -> ok.
 h(M, F)     -> docsh_erl:h(M, F).
+
+-spec h(module(), docsh_erl:name(), arity() | 'any') -> ok.
 h(M, F, A)  -> docsh_erl:h(M, F, A).
 
+-spec s(fun()) -> ok.
 s(Fun)      -> docsh_erl:s(Fun).
+
+-spec s(module(), docsh_erl:name()) -> ok.
 s(M, F)     -> docsh_erl:s(M, F).
+
+-spec s(module(), docsh_erl:name(), arity() | 'any') -> ok.
 s(M, F, A)  -> docsh_erl:s(M, F, A).
 
+-spec t(module()) -> ok.
 t(M)        -> docsh_erl:t(M).
+
+-spec t(module(), docsh_erl:name()) -> ok.
 t(M, T)     -> docsh_erl:t(M, T).
+
+-spec t(module(), docsh_erl:name(), arity() | 'any') -> ok.
 t(M, T, A)  -> docsh_erl:t(M, T, A).

--- a/src/docsh_tracer.erl
+++ b/src/docsh_tracer.erl
@@ -27,6 +27,7 @@
 %%
 %% So, it's best to setup a process which will monitor the trace handler
 %% and print any 'DOWN' messages it receives.
+-spec start() -> {{tracer, pid()}, {tracer_monitor, pid()}}.
 start() ->
     %{ok, Tracer} = dbg:tracer(process, {fun ?MODULE:handler/2, standard_io}),
     {ok, Tracer} = dbg:tracer(process, {fun ?MODULE:handler/2, user}),


### PR DESCRIPTION
Hi, we started including `docsh` as a dependency for `erlang_ls` (https://github.com/erlang-ls/erlang_ls), but warnings due to missing functions were displayed.

This PR adds the missing specs, unless there was a reason for not having them. In that case, please advise.

Also, it looks like the CI pipeline does not check specs.