### PR TITLE
rebar.config: don't use git://

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
  [ {test, [
            {deps, [
                    {xref_runner, "1.0.0"},
-                   {erlsh, {git, "git://github.com/proger/erlsh.git", {branch, "master"}}}
+                   {erlsh, {git, "https://github.com/proger/erlsh.git", {branch, "master"}}}
                   ] }
           ]}]}.
 


### PR DESCRIPTION
git:// has been officially deprecated and removed by github, and no longer functions. https is required for read-only access.